### PR TITLE
Fix: Redundant requirements in CI workflow

### DIFF
--- a/.github/workflows/KeepYourSession-CI.yml
+++ b/.github/workflows/KeepYourSession-CI.yml
@@ -52,7 +52,7 @@ jobs:
   test:
     name: Run the unit tests
     runs-on: windows-latest
-    needs: [install, verify]
+    needs: [verify]
 
     steps:
       - name: Checkout repository
@@ -74,7 +74,7 @@ jobs:
   pre-build-package-verify:
     name: Verify the package before build
     runs-on: windows-latest
-    needs: [install, verify]
+    needs: [verify]
 
     steps:
       - name: Checkout repository
@@ -96,7 +96,7 @@ jobs:
   pre-build-package-compile:
     name: Compile the sources before build
     runs-on: windows-latest
-    needs: [install, verify]
+    needs: [verify]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/KeepYourSession-CI.yml
+++ b/.github/workflows/KeepYourSession-CI.yml
@@ -143,7 +143,7 @@ jobs:
           path: ./node_modules
           key: ${{ hashFiles('./package.json') }}
 
-      - name: Pull the transpiled sources
+      - name: Pull the compiled sources
         uses: actions/cache@v2.1.6
         with:
           path: ./build


### PR DESCRIPTION
After separating `verify` job from `install` job (in PR #16) the requirements of other (further) jobs were outdated.

This pull request fixes it by removing the redundant `install` job from:
*pre-build-package-compile*, *pre-build-package-verify*, *tests*,

This affects the workflow graph by not showing the full path but nearest stages only.