### PR TITLE
Fix: unused legacy PluginApp script

### DIFF
--- a/app/src/PluginApp.js
+++ b/app/src/PluginApp.js
@@ -1,1 +1,0 @@
-document.body.style.border = "5px solid red";


### PR DESCRIPTION
This pull request removes the unused *PluginApp* script from the source codebase.

This *PluginApp* code was generated from the starting of the project from the MDN example of the plugin.
It is no longer needed to be in the project.
